### PR TITLE
Correct calculation of container labels and env to apply

### DIFF
--- a/resource/docker/container/docker_container_resource.go
+++ b/resource/docker/container/docker_container_resource.go
@@ -383,7 +383,7 @@ func resourceRead(d *schema.ResourceData, m interface{}) error {
 				l[k] = v
 			}
 
-			for k := range imageInfo.ContainerConfig.Labels {
+			for k := range imageInfo.Config.Labels {
 				delete(l, k)
 			}
 
@@ -404,7 +404,7 @@ func resourceRead(d *schema.ResourceData, m interface{}) error {
 				}
 			}
 
-			for _, e := range imageInfo.ContainerConfig.Env {
+			for _, e := range imageInfo.Config.Env {
 				se := strings.SplitN(e, "=", 2)
 				if len(se) == 2 {
 					v := env[se[0]]


### PR DESCRIPTION
The output of `docker inspect image` previously (for me) contained the same information in ContainerConfig.Labels and Config.Labels, but this is no longer the case. `ContainerConfig.Labels` is now being reported as null. I've not discovered the root cause, or authoritative docs, however https://forums.docker.com/t/what-is-the-difference-between-containerconfig-and-config-in-image/83232 suggests that Config.Env is correct.